### PR TITLE
Resolve google-api-client gem deprecation

### DIFF
--- a/firebase_token_auth.gemspec
+++ b/firebase_token_auth.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'google-api-client'
+  spec.add_dependency 'google-apis-identitytoolkit_v3'
   spec.add_dependency 'jwt'
 end


### PR DESCRIPTION
Post-install message from google-api-client:
>```
> *******************************************************************************
> The google-api-client gem is deprecated and will likely not be updated further.
> 
> Instead, please install the gem corresponding to the specific service to use.
> For example, to use the Google Drive V3 client, install google-apis-drive_v3.
> For more information, see the FAQ in the OVERVIEW.md file or the YARD docs.
> *******************************************************************************
>```
