### PR TITLE
StringIO requires rewind in order to reuse

### DIFF
--- a/lib/firebase_token_auth/configuration.rb
+++ b/lib/firebase_token_auth/configuration.rb
@@ -40,6 +40,7 @@ module FirebaseTokenAuth
 
       if json_key_io
         json_io = json_key_io.respond_to?(:read) ? json_key_io : File.open(json_key_io)
+        json_io.rewind if json_key_io.respond_to?(:read) 
         parsed = JSON.parse(json_io.read)
         @private_key = OpenSSL::PKey::RSA.new(parsed['private_key'])
         @client_email = parsed['client_email']

--- a/lib/firebase_token_auth/configuration.rb
+++ b/lib/firebase_token_auth/configuration.rb
@@ -29,6 +29,7 @@ module FirebaseTokenAuth
 
       @auth = if json_key_io
                 io = json_key_io.respond_to?(:read) ? json_key_io : File.open(json_key_io)
+                io.rewind if io.respond_to?(:read) 
                 Google::Auth::ServiceAccountCredentials.make_creds(
                   json_key_io: io,
                   scope: scope


### PR DESCRIPTION
When SringIO.new is used for the key, the read method clears up the buffer and requires rewind in order to use it again. 
