### PR TITLE
Fix public key expiration condition

### DIFF
--- a/lib/firebase_token_auth/public_key_manager.rb
+++ b/lib/firebase_token_auth/public_key_manager.rb
@@ -25,7 +25,7 @@ module FirebaseTokenAuth
       end
 
       def expired?
-        @expire_time.to_i > Time.now.to_i
+        @expire_time.to_i <= Time.now.to_i
       end
 
       def cache_control_header_to_expire_time(cache_control_header)


### PR DESCRIPTION
The value that `expired?` returns may be the opposite result what we expected.